### PR TITLE
Improve light theme styling

### DIFF
--- a/app/challenges/ChallengesClient.tsx
+++ b/app/challenges/ChallengesClient.tsx
@@ -99,9 +99,7 @@ export default function ChallengesClient({
 
   // 6) Card-Basis-Stile
   const cardBaseClasses =
-    "bg-white/10 backdrop-blur-md border-transparent sm:border sm:border-white/20 " +
-    "rounded-2xl overflow-hidden shadow-sm hover:border-teal-300 " +
-    "hover:shadow-[0_0_20px_rgba(14,211,181,0.5)] transition";
+    "bg-white border border-gray-200 rounded-2xl overflow-hidden shadow-sm hover:border-teal-300 transition";
 
   return (
     <div className="w-full px-2 sm:px-4 pt-4 overflow-x-hidden">
@@ -125,7 +123,7 @@ export default function ChallengesClient({
               <Link key={c.id} href={`/challenges/${c.id}`} className="block">
                 <div className={`${cardSizeClass} ${cardBaseClasses}`}>
                   {/* Bild-Bereich */}
-                  <div className="h-[75%] relative bg-gray-700">
+                  <div className="h-[75%] relative bg-gray-200">
                     {imgUrl ? (
                       <Image
                         src={imgUrl}

--- a/app/challenges/page.tsx
+++ b/app/challenges/page.tsx
@@ -70,7 +70,7 @@ export default async function ChallengesPage() {
   return (
     <>
       {/* 1) Oben: Gesamtliste aller Challenges (ohne Globe) */}
-      <div style={{ padding: "16px", backgroundColor: "#111" }}>
+      <div style={{ padding: "16px", backgroundColor: "#f0f0f0" }}>
         <ChallengesClient challenges={challenges} showCity={false} />
       </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,7 +29,7 @@ export default function HomePage() {
   ];
 
   return (
-    <div className="relative overflow-hidden bg-black text-white font-sans">
+    <div className="relative overflow-hidden bg-gray-50 text-gray-900 font-sans">
       <Header />
 
       {/* Hero Section */}
@@ -98,12 +98,12 @@ export default function HomePage() {
       </motion.section>
 
       {/* Feature Highlights with 3D tilt */}
-      <section className="py-24 bg-black">
+      <section className="py-24 bg-gray-100">
         <div className="max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-12 px-6">
           {features.map((f, i) => (
             <motion.div
               key={i}
-              className="p-8 bg-black/70 border border-gray-700 rounded-3xl backdrop-blur-md text-center cursor-pointer"
+              className="p-8 bg-white border border-gray-200 rounded-3xl shadow-md text-center cursor-pointer"
               whileHover={{ rotateY: 10, scale: 1.05 }}
               transition={{ type: "spring", stiffness: 200 }}
             >
@@ -111,14 +111,14 @@ export default function HomePage() {
                 {f.icon}
               </div>
               <h3 className="text-2xl font-bold mb-2">{f.title}</h3>
-              <p className="text-gray-400">{f.desc}</p>
+              <p className="text-gray-600">{f.desc}</p>
             </motion.div>
           ))}
         </div>
       </section>
 
       {/* CTA Banner */}
-      <section className="relative py-32 overflow-hidden bg-gradient-to-r from-purple-900 to-indigo-900 text-white text-center">
+      <section className="relative py-32 overflow-hidden bg-gradient-to-r from-purple-500 to-indigo-700 text-white text-center">
         {/* Swirling Rings Background */}
         <motion.div
           className="absolute inset-0 flex items-center justify-center"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Footer: React.FC = () => {
   return (
-    <footer className="bg-gray-900 text-white py-4">
+    <footer className="bg-gray-100 text-gray-600 py-4">
       <div className="container mx-auto text-center">
         © {new Date().getFullYear()} Get Done. Alle Rechte vorbehalten.
       </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
         onMouseLeave={() => setShowHeader(false)}
       >
         <div className="max-w-7xl mx-auto px-4 md:px-6 lg:px-8 py-4 flex items-center justify-between">
-          <Link href="/" className="text-2xl font-bold text-white">
+          <Link href="/" className="text-2xl font-bold text-gray-900">
             Get Done
           </Link>
 
@@ -67,7 +67,7 @@ export default function Header() {
           {showToolbar && <SearchSortFilterSplitBar />}
 
           <button
-            className="md:hidden text-white"
+            className="md:hidden text-gray-900"
             onClick={() => setMobileMenuOpen((o) => !o)}
             aria-label="Menü öffnen"
           >
@@ -78,7 +78,7 @@ export default function Header() {
             )}
           </button>
 
-          <nav className="hidden md:flex items-center space-x-6 text-white">
+          <nav className="hidden md:flex items-center space-x-6 text-gray-900">
             <NavLink href="/">Home</NavLink>
             <NavLink href="/create">Create</NavLink>
             <NavLink href="/allmychallenges">My Challenges</NavLink>
@@ -102,7 +102,7 @@ export default function Header() {
         </div>
 
         {mobileMenuOpen && (
-          <div className="md:hidden bg-black/50 backdrop-blur-md px-4 pb-4 space-y-2">
+          <div className="md:hidden bg-white/90 backdrop-blur-md px-4 pb-4 space-y-2">
             <MobileLink href="/">Home</MobileLink>
             <MobileLink href="/create">Create</MobileLink>
             <MobileLink href="/allmychallenges">My Challenges</MobileLink>
@@ -137,7 +137,7 @@ function NavLink({
   children: React.ReactNode;
 }) {
   return (
-    <Link href={href} className="text-white hover:text-blue-300 transition">
+    <Link href={href} className="text-gray-900 hover:text-blue-600 transition">
       {children}
     </Link>
   );
@@ -158,7 +158,7 @@ function MobileLink({
           ? "page"
           : undefined
       }
-      className="block px-4 py-2 rounded text-gray-100 hover:bg-gray-700"
+      className="block px-4 py-2 rounded text-gray-900 hover:bg-gray-200"
     >
       {children}
     </Link>

--- a/components/SearchSortFilterSplitBar.tsx
+++ b/components/SearchSortFilterSplitBar.tsx
@@ -80,8 +80,8 @@ export default function SearchSortFilterSplitBar() {
       {/* Such-Icon */}
       <button
         onClick={() => setShowSearch((v) => !v)}
-        className={`p-0 rounded-full hover:bg-white/10 transition ${
-          search ? "text-teal-300" : "text-white"
+        className={`p-0 rounded-full hover:bg-gray-200 transition ${
+          search ? "text-teal-500" : "text-gray-900"
         }`}
         title="Suche"
       >
@@ -105,7 +105,7 @@ export default function SearchSortFilterSplitBar() {
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Suche…"
               autoFocus
-              className="w-[80%] max-w-lg h-10 px-4 rounded-full border-2 border-teal-300 bg-black placeholder-teal-300 text-teal-300 focus:outline-none"
+              className="w-[80%] max-w-lg h-10 px-4 rounded-full border-2 border-teal-300 bg-white placeholder-teal-600 text-teal-900 focus:outline-none"
             />
           </motion.form>
         )}
@@ -115,7 +115,7 @@ export default function SearchSortFilterSplitBar() {
       <div className="relative" ref={dropdownRef}>
         <button
           onClick={() => setDropdownOpen((o) => !o)}
-          className="flex items-center p-2 rounded-full hover:bg-white/10 transition text-white"
+          className="flex items-center p-2 rounded-full hover:bg-gray-200 transition text-gray-900"
           title="Sortieren"
         >
           <Sliders size={20} />
@@ -132,7 +132,7 @@ export default function SearchSortFilterSplitBar() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
               transition={{ duration: 0.2 }}
-              className="absolute top-full mt-2 w-44 bg-black/80 text-white rounded-md shadow-lg overflow-hidden z-30"
+              className="absolute top-full mt-2 w-44 bg-white text-gray-900 rounded-md shadow-lg overflow-hidden z-30"
             >
               {sortFields.map((field) => {
                 const active = currentSort === field.key;
@@ -140,8 +140,8 @@ export default function SearchSortFilterSplitBar() {
                   <button
                     key={field.key}
                     onClick={() => toggleSort(field.key)}
-                    className={`flex items-center w-full text-left px-4 py-2 hover:bg-white/10 transition ${
-                      active ? "bg-white/10 font-semibold" : ""
+                    className={`flex items-center w-full text-left px-4 py-2 hover:bg-gray-100 transition ${
+                      active ? "bg-gray-100 font-semibold" : ""
                     }`}
                   >
                     <span>{field.label}</span>
@@ -164,8 +164,8 @@ export default function SearchSortFilterSplitBar() {
       {/* Nur mit Bildern */}
       <button
         onClick={() => setOnlyWithImages((v) => !v)}
-        className={`p-2 rounded-full hover:bg-white/10 transition ${
-          onlyWithImages ? "text-teal-300" : "text-white/40"
+        className={`p-2 rounded-full hover:bg-gray-200 transition ${
+          onlyWithImages ? "text-teal-500" : "text-gray-400"
         }`}
         title="Nur mit Bildern"
       >
@@ -175,14 +175,14 @@ export default function SearchSortFilterSplitBar() {
       {/* Ansicht (Lämpchen) */}
       <button
         onClick={() => setViewCols((v) => (v === 2 ? 1 : 2))}
-        className="flex items-center space-x-1 p-2 rounded-full hover:bg-white/10 transition"
+        className="flex items-center space-x-1 p-2 rounded-full hover:bg-gray-200 transition"
         title="Ansicht wechseln"
       >
         {[1, 2].map((i) => (
           <span
             key={i}
             className={`w-2 h-2 rounded-full transition-colors ${
-              i <= viewCols ? "bg-teal-300" : "bg-white/30"
+              i <= viewCols ? "bg-teal-500" : "bg-gray-300"
             }`}
           />
         ))}


### PR DESCRIPTION
## Summary
- lighten the landing page background and features
- switch challenges listing to light background
- use light header, footer and toolbar styles
- tweak challenge cards for light theme

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e83cc5b883219372966a7afa0373